### PR TITLE
Changed Illuminate support requirement to work with Laravel 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 
 	"require": {
 		"php": ">=5.4.0",
-		"illuminate/support": "4.0.x"
+		"illuminate/support": ">=4.0"
 	},
 
 	"require-dev": {


### PR DESCRIPTION
Didn't get to test this but I guess it should work.
