### PR TITLE
Adding support for custom request methods

### DIFF
--- a/src/Vinelab/Http/Request.php
+++ b/src/Vinelab/Http/Request.php
@@ -75,6 +75,7 @@ Class Request implements RequestInterface{
 	{
 		$cURLOptions = array(
 			CURLOPT_URL            => $this->url,
+			CURLOPT_CUSTOMREQUEST  => $this->method,
 			CURLOPT_RETURNTRANSFER => $this->returnTransfer,
 			CURLOPT_HTTPHEADER     => $this->headers,
 			CURLOPT_HEADER         => true,


### PR DESCRIPTION
Calls such as Client::delete(Request) were still making the request as a GET despite the delete() call being used. Adding a line to the cURL request to set the request method appropriately.
