### PR TITLE
Fixed header parsing for URLs

### DIFF
--- a/src/Vinelab/Http/Response.php
+++ b/src/Vinelab/Http/Response.php
@@ -122,7 +122,7 @@ class Response implements ResponseInterface
         foreach (explode("\r\n", $headers) as $header) {
             if (strpos($header, ':')) {
                 $nestedHeader = explode(':', $header);
-                $parsedHeaders[$nestedHeader[0]] = trim($nestedHeader[1]);
+                $parsedHeaders[array_shift($nestedHeader)] = trim(implode(':', $nestedHeader));
             }
         }
 


### PR DESCRIPTION
Headers like:

Content-Type: application/json
Content-Length: 94
Location: https://example.com/doma/path

were parsed as

[Content-Type] => application/json
[Content-Length] => 94
[Location] => https

