### PR TITLE
Fixed header parsing for values containing colon

### DIFF
--- a/src/Vinelab/Http/Response.php
+++ b/src/Vinelab/Http/Response.php
@@ -122,7 +122,7 @@ class Response implements ResponseInterface
         foreach (explode("\r\n", $headers) as $header) {
             if (strpos($header, ':')) {
                 $nestedHeader = explode(':', $header);
-                $parsedHeaders[$nestedHeader[0]] = trim($nestedHeader[1]);
+                $parsedHeaders[array_shift($nestedHeader)] = trim(implode(':', $nestedHeader));
             }
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -29,7 +29,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $headers = $this->client->get($request)->headers();
 
         $this->assertArrayHasKey('Host', $headers, 'Headers must have Host');
-        $this->assertEquals(static::$serverHost, $headers['Host']);
+        $this->assertEquals(static::$serverHost.':'.static::$serverPort, $headers['Host']);
 
         // custom headers
         $request['url'] = 'http://'.static::serverUrl().'/content_type.php';


### PR DESCRIPTION
Headers like:

Content-Type: application/json
Content-Length: 94
Location: https://example.com/doma/path

were parsed as

[Content-Type] => application/json
[Content-Length] => 94
[Location] => https