### PR TITLE
Don't echo out the return value of curl_exec().

### DIFF
--- a/src/Vinelab/Http/Request.php
+++ b/src/Vinelab/Http/Request.php
@@ -176,6 +176,7 @@ class Request implements RequestInterface
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_MAXREDIRS => $this->maxRedirects,
             CURLOPT_TIMEOUT => $this->timeout,
+            CURLOPT_RETURNTRANSFER => true,
         );
 
         //digest auth support


### PR DESCRIPTION
Just added a new cURL option to return the transfer as a string of the return value of curl_exec() instead of outputting it out directly.