### PR TITLE
Update HttpServiceProvider for Laravel 5.4

### DIFF
--- a/src/Vinelab/Http/HttpServiceProvider.php
+++ b/src/Vinelab/Http/HttpServiceProvider.php
@@ -18,7 +18,7 @@ class HttpServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['vinelab.httpclient'] = $this->app->share(function ($app) {
+        $this->app->singleton('vinelab.httpclient',function ($app) {
             return new Client();
         });
 


### PR DESCRIPTION
laravel 5.4 removes the share method, this uses the singleton method which has been in laravel since 4.2.

Here is a snippet from the [upgrade documentation](https://laravel.com/docs/5.4/upgrade); 

>The share method has been removed from the container. This was a legacy method that has not been documented in several years. If you are using this method, you should begin using the  singleton method instead

Here is the [laravel API documentation that shows](https://laravel.com/api/4.2/Illuminate/Container/Container.html#method_singleton) the singleton method in laravel 4.2. I'm not sure what the package backwards compatibility is but this should be nonbreaking for 4.2 - 5.4.