### PR TITLE
Upgrade tolerance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"require": {
 		"php": ">=5.6.4",
 		"illuminate/support": "*",
-		"tolerance/tolerance": "^0.3.3"
+		"tolerance/tolerance": "^0.4.0"
 	},
 
 	"require-dev": {


### PR DESCRIPTION
when trying to install **Passport package** the dependency of **symfony/psr-http-message-bridge** aren't met , cause tolerance is using version **0.3.3** .

so this PR fixes the issue of installing **Passport** by upgrading **tolerance**