### PR TITLE
Make header() method case-insensitive

### DIFF
--- a/src/Vinelab/Http/Response.php
+++ b/src/Vinelab/Http/Response.php
@@ -46,6 +46,7 @@ class Response implements ResponseInterface
             $this->info = curl_getinfo($cURL);
             $this->headers = $this->parseHeaders($response, $this->info['header_size']);
             $this->content = $this->parseBody($response, $this->info['header_size']);
+            $this->caseInsensitiveHeaders = array_change_key_case($this->headers);
         } else {
             throw new HttpClientRequestFailedException(curl_error($cURL));
         }
@@ -148,7 +149,10 @@ class Response implements ResponseInterface
      */
     public function header($name)
     {
-        return (array_key_exists($name, $this->headers)) ? $this->headers[$name] : null;
+        if (array_key_exists(strtolower($name), $this->caseInsensitiveHeaders)) {
+            return $this->caseInsensitiveHeaders[strtolower($name)];
+        }
+        return null;
     }
 
     /**

--- a/src/Vinelab/Http/Response.php
+++ b/src/Vinelab/Http/Response.php
@@ -152,6 +152,7 @@ class Response implements ResponseInterface
         if (array_key_exists(strtolower($name), $this->caseInsensitiveHeaders)) {
             return $this->caseInsensitiveHeaders[strtolower($name)];
         }
+        
         return null;
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -37,6 +37,10 @@ class ClientTest extends PHPUnit_Framework_TestCase
 
         $this->assertArrayHasKey('Content-Type', $headers);
         $this->assertEquals('application/json', $headers['Content-Type']);
+
+        // RFC7230 case-insensitive header fields
+        $testResponse = $this->client->get($request);
+        $this->assertEquals($testResponse->header('content-type'), $testResponse->header('Content-Type'));
     }
 
     public function testGetRequestWithoutParams()


### PR DESCRIPTION
> Each header field consists of a case-insensitive field name followed by a colon (":"), optional leading whitespace, the field value, and optional trailing whitespace.

HTTP 1/1 - RFC7230

> Just as in HTTP/1.x, header field names are strings of ASCII characters that are compared in a case-insensitive fashion.

HTTP2 - RFC7540

